### PR TITLE
Update example for 2.4.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.google.cloud.dataflow</groupId>
             <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-            <version>2.0.0-beta3</version>
+            <version>2.4.0</version>
         </dependency>
         <!-- slf4j API frontend binding with JUL backend -->
         <dependency>

--- a/src/main/java/com/example/dataflow/PubsubFileInjector.java
+++ b/src/main/java/com/example/dataflow/PubsubFileInjector.java
@@ -17,9 +17,8 @@
 package com.example.dataflow;
 
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.io.PubsubIO;
 import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -80,13 +79,12 @@ public class PubsubFileInjector {
     Pipeline pipeline = Pipeline.create(options);
 
     pipeline
-        .apply(TextIO.Read.from(options.getInput()))
+        .apply(TextIO.read().from(options.getInput()))
         .apply(ParDo.of(new FilterHeaderAndEmpties()))
         .apply(
-            PubsubIO.<String>write()
-                .topic(options.getOutputTopic())
-                .withCoder(StringUtf8Coder.of())
-                .timestampLabel("timestamp"));
+            PubsubIO.writeStrings()
+                    .to(options.getOutputTopic())
+                    .withTimestampAttribute("timestamp"));
 
     pipeline.run();
   }

--- a/src/main/java/com/example/dataflow/TrafficMaxLaneFlow.java
+++ b/src/main/java/com/example/dataflow/TrafficMaxLaneFlow.java
@@ -20,15 +20,15 @@ import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
+import org.apache.avro.reflect.Nullable;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.DefaultCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
-import org.apache.beam.sdk.io.PubsubIO;
 import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -41,8 +41,6 @@ import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-
-import org.apache.avro.reflect.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.joda.time.format.DateTimeFormat;
@@ -377,11 +375,10 @@ public class TrafficMaxLaneFlow {
       rawInput =
           pipeline.apply(
               "StreamFromPubsub",
-              PubsubIO.<String>read()
-                  .withCoder(StringUtf8Coder.of())
-                  .topic(options.getPubsubTopic()));
+              PubsubIO.readStrings()
+                  .fromTopic(options.getPubsubTopic()));
     } else {
-      rawInput = pipeline.apply("ReadFromFile", TextIO.Read.from(options.getInputFile()));
+      rawInput = pipeline.apply("ReadFromFile", TextIO.read().from(options.getInputFile()));
     }
 
     // row... => <stationId, LaneInfo> ...
@@ -396,7 +393,7 @@ public class TrafficMaxLaneFlow {
                 SlidingWindows.of(Duration.standardMinutes(options.getWindowDuration()))
                     .every(Duration.standardMinutes(options.getWindowSlideEvery()))))
         .apply(new MaxLaneFlow())
-        .apply(BigQueryIO.Write.to(tableRef).withSchema(FormatMaxesFn.getSchema()));
+        .apply(BigQueryIO.<TableRow>write().to(tableRef).withSchema(FormatMaxesFn.getSchema()));
 
     PipelineResult result = pipeline.run();
     // dataflowUtils will try to cancel the pipeline and the injector before the program exists.

--- a/src/main/java/com/example/dataflow/TrafficMaxLaneFlow.java
+++ b/src/main/java/com/example/dataflow/TrafficMaxLaneFlow.java
@@ -393,7 +393,7 @@ public class TrafficMaxLaneFlow {
                 SlidingWindows.of(Duration.standardMinutes(options.getWindowDuration()))
                     .every(Duration.standardMinutes(options.getWindowSlideEvery()))))
         .apply(new MaxLaneFlow())
-        .apply(BigQueryIO.<TableRow>write().to(tableRef).withSchema(FormatMaxesFn.getSchema()));
+        .apply(BigQueryIO.<TableRow>writeTableRows().to(tableRef).withSchema(FormatMaxesFn.getSchema()));
 
     PipelineResult result = pipeline.run();
     // dataflowUtils will try to cancel the pipeline and the injector before the program exists.


### PR DESCRIPTION
The dataflow service no longer accepts 2.0.0Beta3 as a valid Dataflow SDK version.

Update the example code to account for code changes required when updating to Dataflow/Beam 2.4.0.


Relevant stacktrace:
```
Dataflow SDK version: 2.0.0-beta3                                                                                                                                                                                  
Sep 04, 2018 11:28:28 PM org.apache.beam.sdk.util.RetryHttpRequestInitializer$LoggingHttpBackoffUnsuccessfulResponseHandler handleResponse                                                                         
WARNING: Request failed with code 400, will NOT retry: https://dataflow.googleapis.com/v1b3/projects/qwiklabs-gcp-a2b4915c8a1689bb/locations/us-central1/jobs                                                      
[WARNING]                                                                                                                                                                                                          
java.lang.reflect.InvocationTargetException                                                                                                                                                                        
    ┆   at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)                                                                                                                                             
    ┆   at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)                                                                                                                           
    ┆   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)                                                                                                                   
    ┆   at java.lang.reflect.Method.invoke(Method.java:498)                                                                                                                                                        
    ┆   at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)                                                                                                                                        
    ┆   at java.lang.Thread.run(Thread.java:748)                                                                                                                                                                   
Caused by: java.lang.RuntimeException: Failed to create a workflow job: (2cae3faffbc1f8a4): The workflow was automatically rejected by the service because it uses an unsupported SDK version 2.0.0-beta3. For a list of supported SDK versions, see:                                                                                                                                                                                 
https://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases                                                                                                                                 
    ┆   at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:616)                                                                                                                            
    ┆   at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:151)                                                                                                                            
    ┆   at org.apache.beam.sdk.Pipeline.run(Pipeline.java:210)                                                                                                                                                     
    ┆   at com.example.dataflow.StarterPipeline.main(StarterPipeline.java:68)                                                                                                                                      
    ┆   ... 6 more                                                                                                                                                                                                 
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request                                                                                                                      
{                                                                                                                                                                                                                  
  "code" : 400,                                                                                                                                                                                                    
  "errors" : [ {                                                                                                                                                                                                   
    "domain" : "global",                                                                                                                                                                                           
    "message" : "(2cae3faffbc1f8a4): The workflow was automatically rejected by the service because it uses an unsupported SDK version 2.0.0-beta3. For a list of supported SDK versions, see: \nhttps://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases",                                                                                                                                                 
    "reason" : "badRequest"                                                                                                                                                                                        
  } ],                                                                                                                                                                                                             
  "message" : "(2cae3faffbc1f8a4): The workflow was automatically rejected by the service because it uses an unsupported SDK version 2.0.0-beta3. For a list of supported SDK versions, see: \nhttps://cloud.google.com/dataflow/support#support-status-for-dataflow-sdk-releases",                                                                                                                                                   
  "status" : "INVALID_ARGUMENT"                                                                                                                                                                                    
}                                                                                                                                                                                                                  
    ┆   at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)                                                                                            
    ┆   at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)                                                            
    ┆   at org.apache.beam.runners.dataflow.DataflowRunner.run(DataflowRunner.java:603)                                                                                                                            
                                                                                          
```